### PR TITLE
Adding pull stop

### DIFF
--- a/docs/staking.md
+++ b/docs/staking.md
@@ -34,7 +34,7 @@ You can earn TAD continuously by staking your LP tokens. Follow these steps to s
 
 ![Stake LP tokens](https://indodax.academy/wp-content/uploads/2020/11/staking-tadpole-finance-3-1.jpg.webp)
 
-3. Click the “Stake” button and approve the transaction using Metamask
+3. Click the “Stake” button and approve the transaction using Metamask.
 4. Wait for the transaction to be confirmed by the Ethereum Network. If the transaction is successful, your LP Token balance will be deducted.
 5. Check the [staking page](https://tadpole.finance/staking.html) regularly to see the amount of TAD that can be claimed.
 


### PR DESCRIPTION
Adding pull stop to end a sentence is mandatory to show a professionalism in journalistic way.